### PR TITLE
New_Job tweaks to make it shorter.

### DIFF
--- a/fraqbot/Local/newjob.py
+++ b/fraqbot/Local/newjob.py
@@ -75,13 +75,13 @@ class NewJob(Lego):
         random_company = random.choice(found_companies)
 
         final_string = ' '.join([
-            'Congrats on the new role!',
             random.choice(found_role_modifiers),
             random.choice(found_roles),
             'at',
-            '<https://en.wikipedia.org/wiki/{}|{}>'.format(
+            '{} (<https://en.wikipedia.org/wiki/{}|en.wikipedia.org/wiki/{}>)'.format(
+                    random_company,
                     random_company.replace(' ', '_'),
-                    random_company
+                    random_company.replace(' ', '_')
                 )
             ])
 

--- a/fraqbot/Local/newjob.py
+++ b/fraqbot/Local/newjob.py
@@ -78,7 +78,8 @@ class NewJob(Lego):
             random.choice(found_role_modifiers),
             random.choice(found_roles),
             'at',
-            '{} (<https://en.wikipedia.org/wiki/{}|en.wikipedia.org/wiki/{}>)'.format(
+            ('{} (<https://en.wikipedia.org/wiki/{}' +
+                '|en.wikipedia.org/wiki/{}>)').format(
                     random_company,
                     random_company.replace(' ', '_'),
                     random_company.replace(' ', '_')


### PR DESCRIPTION
I removed the intro text (Congrats!...) and I formatted the link so that it will NOT unfurl. This is per Slack API docs:


> Even though unfurl_links is true, this link has a label that matches the URL minus the protocol, so the link will not unfurl:
`{
    "text": "<https://api.slack.com|api.slack.com>",
    "unfurl_links": true
}`

https://api.slack.com/reference/messaging/link-unfurling#no_unfurling_please