### PR TITLE
AK: Only use 5 least-posting users / Prevent choosing user with no valid words

### DIFF
--- a/fraqbot/Local/coins.py
+++ b/fraqbot/Local/coins.py
@@ -346,8 +346,13 @@ class CoinsPoolManager(CoinsBase):
                 and w.lower() not in self.common_words
             ]
 
+        word_pool_items_filtered = [
+            item for item in
+            word_pool.items() if
+            len(item[1]) > 0]
+
         word_pool_sorted = dict(sorted(
-                                    word_pool.items(),
+                                    word_pool_items_filtered,
                                     key=lambda item: len(item[1]),
                                     reverse=True
                                     ))

--- a/fraqbot/Local/coins.py
+++ b/fraqbot/Local/coins.py
@@ -346,7 +346,15 @@ class CoinsPoolManager(CoinsBase):
                 and w.lower() not in self.common_words
             ]
 
-        user = choice(list(word_pool.keys()))
+        word_pool_sorted = dict(sorted(
+                                    word_pool.items(),
+                                    key=lambda item: len(item[1]),
+                                    reverse=True
+                                    ))
+
+        user_list = list(word_pool_sorted.keys())[0:5]
+
+        user = choice(user_list)
         word = choice(word_pool[user])
         return word, user
 

--- a/fraqbot/Local/helpers.py
+++ b/fraqbot/Local/helpers.py
@@ -223,7 +223,10 @@ class CustomFunctions(functions.Functions):
     def _func_lower(self, value):
         return value.lower()
 
-    @functions.signature({'types': ['string']}, {'types': ['string']}, {'types': ['number']})
+    @functions.signature(
+        {'types': ['string']},
+        {'types': ['string']},
+        {'types': ['number']})
     def _func_split_items(self, value, _split, count):
         if count < 1:
             return value


### PR DESCRIPTION
Fix 1: (Fix for Pard's foolishness). Don't choose users who posted a ton. Sort by words length, and draw from only the 5 who posted least valid words, rather than the full 10 users found in db query.

Fix 2: If some users only posted words <3 in length, or only common words, their list would be empty. Filter out users with no valid words posted.